### PR TITLE
Re: https://github.com/melpa/melpa/pull/6151

### DIFF
--- a/todoist.el
+++ b/todoist.el
@@ -318,11 +318,7 @@ P is a prefix argument to select a project."
   "Keymap for `todoist-mode'.")
 
 (define-derived-mode todoist-mode org-mode "Todoist"
-  "Special mode for todoist buffers."
-  (setq mode-name "Todoist")
-  (setq major-mode 'todoist-mode)
-  (use-local-map todoist-mode-map)
-  (run-mode-hooks 'kubel-mode-hook))
+  "Special mode for todoist buffers.")
 
 ;; main function
 (defun todoist ()

--- a/todoist.el
+++ b/todoist.el
@@ -50,6 +50,8 @@
 (require 'url)
 (require 'url-http)
 
+(defvar url-http-end-of-headers)  ; silence byte-compiler warnings
+
 (defvar todoist-token
   (getenv "TODOIST_TOKEN"))
 


### PR DESCRIPTION
Silenced final byte-compiler warning with defvar.  I also took the liberty of removing some of the commands that are already run implicitly when you define a derived mode.  Most of them are harmless but create opportunities for discrepancies.  Running hooks explicitly actually creates a situation where hooks are run twice (but in this case we were mistakenly running kubel-mode's hooks).

Re: https://github.com/melpa/melpa/pull/6151 