### PR TITLE
Use recommended API endpoint

### DIFF
--- a/todoist.el
+++ b/todoist.el
@@ -56,7 +56,7 @@
   (getenv "TODOIST_TOKEN"))
 
 (defconst todoist-url
-  "https://beta.todoist.com/API/v8")
+  "https://api.todoist.com/rest/v1")
 
 (defconst todoist-buffer-name
   "*todoist*")


### PR DESCRIPTION
Fixes the error: `json-read: JSON readtable error: 80`

Calls are being made to the `https://beta.todoist.com/API/v8` endpoint. However, when the initial call is made to `https://beta.todoist.com/API/v8/projects`, the following `plain-text` (hence the JSON error) message is returned:

```
Please use https://api.todoist.com/rest/v1/ endpoint.
See https://developer.todoist.com/rest/v1/ for details.
```