### PR TITLE
Fix insertion to the bottom of the sub-heading

### DIFF
--- a/todoist.el
+++ b/todoist.el
@@ -188,7 +188,10 @@ TODO is boolean to show TODO tag."
     (org-deadline nil (todoist--task-date task)))
   (org-set-property "TODOIST_ID" (format "%s" (todoist--task-id task)))
   (org-set-property "TODOIST_PROJECT_ID" (format "%s" (todoist--task-project-id task)))
-  (insert (format "\n%s %s\n" (make-string level ?\s) (todoist--task-description task))))
+  (goto-char (point-max))
+  (when-let ((description (todoist--task-description task))
+             (not-empty (> (length description) 0)))
+    (insert (format "\n%s %s\n" (make-string level ?\s) description))))
 
 (defun todoist--insert-project (project tasks)
   "Insert the current project and matching tasks as org buttet list.


### PR DESCRIPTION
The description was insert and the top element of the task item:
Example:

```
** TODO Task with description

   This is the description

   DEADLINE: <2021-09-02 Thu>
   :PROPERTIES:
   :TODOIST_ID: 5122885640
   :TODOIST_PROJECT_ID: 2208047417
   :END:
```

This order causes error to get the task if for the `update` operation.

This fix inserts the description at the bottom like this:

```
** TODO Task with description
   DEADLINE: <2021-09-02 Thu>
   :PROPERTIES:
   :TODOIST_ID: 5122885640
   :TODOIST_PROJECT_ID: 2208047417
   :END:

   This is the description
```