### PR TITLE
Fix description indentation

### DIFF
--- a/todoist.el
+++ b/todoist.el
@@ -191,7 +191,7 @@ TODO is boolean to show TODO tag."
   (goto-char (point-max))
   (when-let ((description (todoist--task-description task))
              (not-empty (> (length description) 0)))
-    (insert (format "\n%s %s\n" (make-string level ?\s) description))))
+    (insert (replace-regexp-in-string (rx line-start) (make-string level ?\s) description))))
 
 (defun todoist--insert-project (project tasks)
   "Insert the current project and matching tasks as org buttet list.


### PR DESCRIPTION
Indent every line of description text so that asterisk-style bullet points won't be mistaken for org headings.

---

**Example**

Screenshot of task from Todoist website:
![2021-09-21-132212_343x116_scrot](https://user-images.githubusercontent.com/5241169/134226344-d00f068e-8331-433b-95d5-5041315850d1.png)

Original behavior:
```
*** Example
    :PROPERTIES:
    :TODOIST_ID: <redacted>
    :TODOIST_PROJECT_ID: <redacted>
    :END:

    * bullet point in description
* another
```

With this PR:
```
*** Example
    :PROPERTIES:
    :TODOIST_ID: 5175619419
    :TODOIST_PROJECT_ID: 2161829187
    :END:
   * bullet point in description
   * another
```