### PR TITLE
Option to use "scheduled" instead of "deadline" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ these menus will respectively allow you to:
 
 - `todoist-show-all`
   If true, show all tasks un-collpased. Default is nil for default view.
+  
+- `todoist-use-scheduled-instead-of-deadline`
+  If true, use SCHEDULED instead of DEADLINE for tasks in org-mode buffers and files
+
+  :group 'todoist
 
 ## Disclaimer
 This extension is not created by, affiliated with, or supported by Doist.

--- a/todoist.el
+++ b/todoist.el
@@ -366,9 +366,9 @@ P is a prefix argument to select a project."
   (interactive)
   (let ((task-id (todoist--under-cursor-task-id))
         (content (read-string "Task content: " (org-entry-get nil "ITEM")))
-        (if todoist-use-scheduled-instead-of-deadline
-            (due (read-string "Task due: " (todoist--parse-org-time-string (org-entry-get nil "SCHEDULED"))))
-            (due (read-string "Task due: " (todoist--parse-org-time-string (org-entry-get nil "DEADLINE"))))))
+        (due (if todoist-use-scheduled-instead-of-deadline
+          (read-string "Task due: " (todoist--parse-org-time-string (org-entry-get nil "SCHEDULED")))
+          (read-string "Task due: " (todoist--parse-org-time-string (org-entry-get nil "DEADLINE"))))))
     (todoist--query "POST" (format "/tasks/%s" task-id) `(("content" . ,content) ("due_string" . ,due)))
     (todoist)))
 

--- a/todoist.el
+++ b/todoist.el
@@ -19,7 +19,7 @@
 ;; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
 ;; USA
 
-;; Version: 1.0
+;; Version: 1.1
 ;; Author: Adrien Brochard
 ;; Keywords: todoist task todo comm
 ;; URL: https://github.com/abrochard/emacs-todoist

--- a/todoist.el
+++ b/todoist.el
@@ -368,8 +368,7 @@ P is a prefix argument to select a project."
         (content (read-string "Task content: " (org-entry-get nil "ITEM")))
         (if todoist-use-scheduled-instead-of-deadline
             (due (read-string "Task due: " (todoist--parse-org-time-string (org-entry-get nil "SCHEDULED"))))
-            (due (read-string "Task due: " (todoist--parse-org-time-string (org-entry-get nil "DEADLINE"))))
-        )
+            (due (read-string "Task due: " (todoist--parse-org-time-string (org-entry-get nil "DEADLINE"))))))
     (todoist--query "POST" (format "/tasks/%s" task-id) `(("content" . ,content) ("due_string" . ,due)))
     (todoist)))
 

--- a/todoist.el
+++ b/todoist.el
@@ -87,7 +87,7 @@
   :group 'todoist
   :type 'string)
 
-(defcustom todoist-use-scheduled-instead-of-deadline t
+(defcustom todoist-use-scheduled-instead-of-deadline nil
   "If not nil, use SCHEDULED instead of DEADLINE in org files."
   :group 'todoist
   :type 'bool)


### PR DESCRIPTION
Adds an option to use "scheduled" instead of "deadline" when showing tasks from Todoist in org-mode.

( Fixes #36  )