### PR TITLE
Fixed buffer dupe bug caused by write-file changing temp buffer

### DIFF
--- a/todoist.el
+++ b/todoist.el
@@ -400,7 +400,7 @@ P is a prefix argument to select a project."
     (let ((buffer (get-file-buffer todoist-backing-buffer)))
       (when buffer
         (kill-buffer buffer)))
-    (write-file todoist-backing-buffer)))
+    (write-region nil nil todoist-backing-buffer)))
 
 ;; transient interface
 (transient-define-prefix todoist-task-menu ()


### PR DESCRIPTION
Hi, 

If we enter a file path for `todoist-backing-buffer`, the task management functions begin to create duplicate Todoist buffers when run, including task creation and deletion. Attaching a video here of me creating a couple tasks and deleting them, creating a duplicate buffer and causing the focus to switch between buffers. This doesn't happen if `todoist-backing-buffer` is `nil`.

From briefly looking at the package it looks like this is because the `todoist-write-to-file-if-needed` function ends with a `write-file` to the `todoist-backin

Uploading todoist-bug-2023-12-28_10.24.21.mp4…

g-buffer` path, saving it. In doing so, what was supposed to be a temp buffer called *Todoist* becomes the buffer with the title of the `todoist-backing-buffer` filename.

This is fixed just by changing `write-file` to `write-region`, since the latter does not alter the buffer in any way. The temp *Todoist* buffer lives on happily ever after!

Awesome package by the way!

Let me know if you have any questions or if I've missed something.